### PR TITLE
Hide tracebacks / stderr in dashboards

### DIFF
--- a/dashboards_bundlers/local_deploy/static/urth/dashboard.css
+++ b/dashboards_bundlers/local_deploy/static/urth/dashboard.css
@@ -116,3 +116,9 @@ body .kernel_controls {
 #dashboard-container img.unconfined {
     max-width: 100%;
 }
+
+/* hide stderr and exceptions */
+.urth-dashboard .container .cell .output_stderr,
+.urth-dashboard .container .cell .output_error {
+    display: none !important;
+}

--- a/dashboards_bundlers/local_deploy/static/urth/dashboard.css
+++ b/dashboards_bundlers/local_deploy/static/urth/dashboard.css
@@ -119,6 +119,7 @@ body .kernel_controls {
 
 /* hide stderr and exceptions */
 .urth-dashboard .container .cell .output_stderr,
-.urth-dashboard .container .cell .output_error {
+.urth-dashboard .container .cell .output_error,
+.urth-dashboard .container .cell .thebe-message {
     display: none !important;
 }


### PR DESCRIPTION
Mimic the styling applied to hide tracebacks and stderr within Jupyter Notebook when in dashboard mode.