### PR TITLE
Extend dashboard server upload bundler

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,13 +4,14 @@ python:
     - 3.3
     - 3.4
     - 3.5
-script:
-    - pip install "notebook>=4.0,<5.0"
+install:
+    - pip install "notebook>=4.0,<5.0" requests jupyter_dashboards
+before_script:
     - mkdir -p /home/travis/.jupyter/nbconfig
     - jupyter notebook --generate-config
-    - pip install jupyter_dashboards
     - jupyter dashboards install --user --symlink
     - jupyter dashboards activate
+script:
     - python setup.py sdist
     - pip install --no-use-wheel --no-deps dist/*.tar.gz
     - python -B -m unittest discover -s test

--- a/Makefile
+++ b/Makefile
@@ -65,8 +65,10 @@ _dev:
 		-p 9500:8888 \
 		-e AUTORELOAD=$(AUTORELOAD) \
 		-e DASHBOARD_SERVER_URL=$(DASHBOARD_SERVER_URL) \
+		-e DASHBOARD_REDIRECT_URL=$(DASHBOARD_REDIRECT_URL) \
 		-e DASHBOARD_SERVER_AUTH_TOKEN=$(DASHBOARD_SERVER_AUTH_TOKEN) \
 		-v `pwd`:/src \
+		-v `pwd`/etc/notebooks:/home/jovyan/work \
 		$(DEV_REPO) bash -c '$(LANG_SETUP_CMD) && $(EXT_DEV_SETUP) && $(CMD)'
 
 install: CMD?=exit

--- a/README.md
+++ b/README.md
@@ -51,9 +51,12 @@ The second converts your notebook to a dashboard web application and zips it up 
 4. Unzip the download.
 5. Refer to the `README.md` in the unzipped folder for deployment requirements.
 
-The third directly sends your notebook to a Jupyter Dashboards Server. To use it:
+The third directly sends your notebook to a [Jupyter Dashboards Server](https://github.com/jupyter-incubator/dashboards_nodejs_app). To use it:
 
-1. Set the `DASHBOARD_SERVER_URL` environment variable, the `DASHBOARD_SERVER_AUTH_TOKEN` variable if an upload token is required, and launch the `jupyter notebook`.
+1. Set the environment variables below and launch your `jupyter notebook`.
+    * `DASHBOARD_SERVER_URL` - protocol, hostname, and port of the dashboard server to which to send dashboard notebooks
+    * `DASHBOARD_REDIRECT_URL` (optional) - protocol, hostname, and port to use when redirecting the user's browser after upload if different from `DASHBOARD_SERVER_URL`
+    * `DASHBOARD_SERVER_AUTH_TOKEN` (optional) - upload token is required by the dashboard server
 2. Write a notebook.
 3. Define a dashboard layout using the `jupyter_dashboards` extension.
 4. Click *File &rarr; Deploy as &rarr; Dashboard on Jupyter Dashboard Server*.

--- a/dashboards_bundlers/server_upload/__init__.py
+++ b/dashboards_bundlers/server_upload/__init__.py
@@ -43,7 +43,8 @@ def bundle(handler, abs_nb_path):
                 headers['Authorization'] = token
             result = requests.post(upload_url, files={'file': notebook},
                 headers=headers, timeout=60)
-            result.raise_for_status()
+            if result.status_code >= 400:
+                raise web.HTTPError(result.status_code)
 
         # Redirect for client might be different from internal upload URL
         redirect_server = os.getenv('DASHBOARD_REDIRECT_URL')

--- a/dashboards_bundlers/server_upload/__init__.py
+++ b/dashboards_bundlers/server_upload/__init__.py
@@ -5,7 +5,7 @@ import os
 import requests
 from notebook.utils import url_path_join
 from tornado import escape, web
-from tornado.log import access_log
+from tornado.log import access_log, app_log
 
 UPLOAD_ENDPOINT = '/_api/notebooks/'
 VIEW_ENDPOINT = '/dashboards/'
@@ -17,15 +17,42 @@ def bundle(handler, abs_nb_path):
     # Get name of notebook from filename
     notebook_basename = os.path.basename(abs_nb_path)
     notebook_name = os.path.splitext(notebook_basename)[0]
-    if 'DASHBOARD_SERVER_URL' in os.environ:
-        dashboard_url = url_path_join(os.getenv('DASHBOARD_SERVER_URL'), UPLOAD_ENDPOINT, escape.url_escape(notebook_name, False))
+
+    # Make information about the request Host header available for use in
+    # constructing the urls
+    segs = handler.request.host.split(':')
+    hostname = segs[0]
+    if len(segs) > 1:
+        port = segs[1]
+    else:
+        port = ''
+    protocol = handler.request.protocol
+
+    # Treat empty as undefined
+    dashboard_server = os.getenv('DASHBOARD_SERVER_URL')
+    if dashboard_server:
+        dashboard_server = dashboard_server.format(protocol=protocol,
+            hostname=hostname, port=port)
+        upload_url = url_path_join(dashboard_server, UPLOAD_ENDPOINT,
+            escape.url_escape(notebook_name, False))
         with open(abs_nb_path, 'rb') as notebook:
             headers = {}
-            if 'DASHBOARD_SERVER_AUTH_TOKEN' in os.environ:
-                headers['Authorization'] = os.getenv('DASHBOARD_SERVER_AUTH_TOKEN')
-            result = requests.post(dashboard_url, files={'file': notebook}, headers=headers, timeout=60)
+            token = os.getenv('DASHBOARD_SERVER_AUTH_TOKEN')
+            if token:
+                # TODO: server side should expect Authorization: token <value>
+                headers['Authorization'] = token
+            result = requests.post(upload_url, files={'file': notebook},
+                headers=headers, timeout=60)
             result.raise_for_status()
-            handler.redirect(url_path_join(os.getenv('DASHBOARD_SERVER_URL'), VIEW_ENDPOINT, escape.url_escape(notebook_name, False)))
+
+        # Redirect for client might be different from internal upload URL
+        redirect_server = os.getenv('DASHBOARD_REDIRECT_URL')
+        if redirect_server:
+            redirect_root = redirect_server.format(hostname=hostname,
+                port=port, protocol=protocol)
+        else:
+            redirect_root = dashboard_server
+        handler.redirect(url_path_join(redirect_root, VIEW_ENDPOINT, escape.url_escape(notebook_name, False)))
     else:
         access_log.debug('Can not deploy, DASHBOARD_SERVER_URL not set')
         raise web.HTTPError(500, log_message='No dashboard server configured')

--- a/etc/notebooks/.ipynb_checkpoints/hello_world-checkpoint.ipynb
+++ b/etc/notebooks/.ipynb_checkpoints/hello_world-checkpoint.ipynb
@@ -1,0 +1,134 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "urth": {
+     "dashboard": {
+      "layout": {
+       "col": 0,
+       "height": 2,
+       "row": 0,
+       "width": 8
+      }
+     }
+    }
+   },
+   "source": [
+    "# Hello World"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "urth": {
+     "dashboard": {
+      "layout": {
+       "col": 0,
+       "height": 2,
+       "row": 2,
+       "width": 5
+      }
+     }
+    }
+   },
+   "outputs": [],
+   "source": [
+    "print('Tick tock goes the kernel clock ...')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true,
+    "urth": {
+     "dashboard": {}
+    }
+   },
+   "outputs": [],
+   "source": [
+    "from IPython.display import HTML, display, clear_output\n",
+    "import time"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true,
+    "urth": {
+     "dashboard": {}
+    }
+   },
+   "outputs": [],
+   "source": [
+    "start = 0x1f550"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "urth": {
+     "dashboard": {
+      "layout": {
+       "col": 5,
+       "height": 2,
+       "row": 2,
+       "width": 4
+      }
+     }
+    }
+   },
+   "outputs": [],
+   "source": [
+    "for i in range(11):\n",
+    "    clear_output()\n",
+    "    display(HTML('&#{};'.format(start + i)))\n",
+    "    time.sleep(0.5)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.4.3"
+  },
+  "urth": {
+   "dashboard": {
+    "cellMargin": 10,
+    "defaultCellHeight": 20,
+    "layoutStrategy": "packed",
+    "maxColumns": 12
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/etc/notebooks/hello_world.ipynb
+++ b/etc/notebooks/hello_world.ipynb
@@ -1,0 +1,134 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "urth": {
+     "dashboard": {
+      "layout": {
+       "col": 0,
+       "height": 2,
+       "row": 0,
+       "width": 8
+      }
+     }
+    }
+   },
+   "source": [
+    "# Hello World"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "urth": {
+     "dashboard": {
+      "layout": {
+       "col": 0,
+       "height": 2,
+       "row": 2,
+       "width": 5
+      }
+     }
+    }
+   },
+   "outputs": [],
+   "source": [
+    "print('Tick tock goes the kernel clock ...')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true,
+    "urth": {
+     "dashboard": {}
+    }
+   },
+   "outputs": [],
+   "source": [
+    "from IPython.display import HTML, display, clear_output\n",
+    "import time"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true,
+    "urth": {
+     "dashboard": {}
+    }
+   },
+   "outputs": [],
+   "source": [
+    "start = 0x1f550"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "urth": {
+     "dashboard": {
+      "layout": {
+       "col": 5,
+       "height": 2,
+       "row": 2,
+       "width": 4
+      }
+     }
+    }
+   },
+   "outputs": [],
+   "source": [
+    "for i in range(11):\n",
+    "    clear_output()\n",
+    "    display(HTML('&#{};'.format(start + i)))\n",
+    "    time.sleep(0.5)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.4.3"
+  },
+  "urth": {
+   "dashboard": {
+    "cellMargin": 10,
+    "defaultCellHeight": 20,
+    "layoutStrategy": "packed",
+    "maxColumns": 12
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/test/test_server_upload.py
+++ b/test/test_server_upload.py
@@ -1,0 +1,100 @@
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+
+import unittest
+import copy
+import os
+import dashboards_bundlers.server_upload as converter
+from tornado import web
+
+class MockResult(object):
+    def __init__(self, status_code):
+        self.status_code = status_code
+
+class MockPost(object):
+    def __init__(self, status_code):
+        self.args = None
+        self.kwargs = None
+        self.status_code = status_code
+
+    def __call__(self, *args, **kwargs):
+        if self.args or self.kwargs:
+            raise RuntimeError('MockPost already invoked')
+        self.args = args
+        self.kwargs = kwargs
+        return MockResult(self.status_code)
+
+class MockRequest(object):
+    def __init__(self, host, protocol):
+        self.host = host
+        self.protocol = protocol
+
+class MockHandler(object):
+    def __init__(self, host='notebook-server:8888', protocol='http'):
+        self.request = MockRequest(host, protocol)
+        self.last_redirect = None
+
+    def redirect(self, location):
+        self.last_redirect = location
+
+class TestServerUpload(unittest.TestCase):
+    def setUp(self):
+        self.origin_env = copy.deepcopy(os.environ)
+        converter.requests.post = MockPost(200)
+
+    def tearDown(self):
+        os.environ = self.origin_env
+
+    def test_no_server(self):
+        '''Should error if no server URL is set.'''
+        handler = MockHandler('fake-host:8000', 'http')
+        self.assertRaises(web.HTTPError, converter.bundle,
+            handler, 'test/resources/no_imports.ipynb')
+
+    def test_upload_notebook(self):
+        '''Should POST the notebook and redirect to the dashboard server.'''
+        os.environ['DASHBOARD_SERVER_URL'] = 'http://dashboard-server'
+        handler = MockHandler()
+        converter.bundle(handler, 'test/resources/no_imports.ipynb')
+
+        args = converter.requests.post.args
+        kwargs = converter.requests.post.kwargs
+        self.assertEqual(args[0], 'http://dashboard-server/_api/notebooks/no_imports')
+        self.assertTrue(kwargs['files']['file'])
+        self.assertEqual(kwargs['headers'], {})
+        self.assertEqual(handler.last_redirect,
+            'http://dashboard-server/dashboards/no_imports')
+
+    def test_upload_token(self):
+        '''Should include an auth token in the request.'''
+        os.environ['DASHBOARD_SERVER_URL'] = 'http://dashboard-server'
+        os.environ['DASHBOARD_SERVER_AUTH_TOKEN'] = 'fake-token'
+        handler = MockHandler()
+        converter.bundle(handler, 'test/resources/no_imports.ipynb')
+
+        kwargs = converter.requests.post.kwargs
+        self.assertEqual(kwargs['headers'],
+            {'Authorization' : 'fake-token'})
+
+    def test_url_interpolation(self):
+        '''Should build the server URL from the request Host header.'''
+        os.environ['DASHBOARD_SERVER_URL'] = '{protocol}://{hostname}:8889'
+        handler = MockHandler('notebook-server:8888', 'https')
+        converter.bundle(handler, 'test/resources/no_imports.ipynb')
+
+        args = converter.requests.post.args
+        self.assertEqual(args[0], 'https://notebook-server:8889/_api/notebooks/no_imports')
+        self.assertEqual(handler.last_redirect,
+            'https://notebook-server:8889/dashboards/no_imports')
+
+    def test_redirect(self):
+        '''Should redirect to the given URL'''
+        os.environ['DASHBOARD_SERVER_URL'] = '{protocol}://{hostname}:8889'
+        os.environ['DASHBOARD_REDIRECT_URL'] = 'http://{hostname}:3000'
+        handler = MockHandler('notebook-server:8888', 'https')
+        converter.bundle(handler, 'test/resources/no_imports.ipynb')
+
+        args = converter.requests.post.args
+        self.assertEqual(args[0], 'https://notebook-server:8889/_api/notebooks/no_imports')
+        self.assertEqual(handler.last_redirect,
+            'http://notebook-server:3000/dashboards/no_imports')


### PR DESCRIPTION
* Include a test notebook
* Support a `DASHBOARD_REDIRECT_URL` for when the public URL differs from the private (e.g., docker links)
* Support interpolation of the request hostname, port, and protocol from the notebook server request
* Tests

Fixes #15 