### PR TITLE
[Issue: 14] Upload to Jupyter Dashboard Server should include associated resources

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,12 @@ python:
     - 3.4
     - 3.5
 install:
-    - pip install "notebook>=4.0,<5.0" requests jupyter_dashboards
+    - pip install "notebook>=4.0,<5.0" requests jupyter_cms jupyter_dashboards
 before_script:
     - mkdir -p /home/travis/.jupyter/nbconfig
     - jupyter notebook --generate-config
+    - jupyter cms install --user --symlink
+    - jupyter cms activate
     - jupyter dashboards install --user --symlink
     - jupyter dashboards activate
 script:

--- a/dashboards_bundlers/local_deploy/__init__.py
+++ b/dashboards_bundlers/local_deploy/__init__.py
@@ -132,7 +132,7 @@ def bundle_web_static(output_path):
     for comp_dir in component_dirs:
         shutil.copytree(pjoin(src_components, comp_dir), pjoin(dest_components, comp_dir))
 
-def bundle_declarative_widgets(output_path, notebook_file):
+def bundle_declarative_widgets(output_path, notebook_file, widget_folder='static'):
     '''
     Adds frontend bower components dependencies into the bundle for the dashboard
     application. Creates the following directories under output_path:
@@ -147,6 +147,7 @@ def bundle_declarative_widgets(output_path, notebook_file):
 
     :param output_path: The output path of the dashboard being assembled
     :param notebook_file: The absolute path to the notebook file being packaged
+    :param widget_folder: Subfolder name in which the widgets should be contained.
     '''
     widgets_dir = pjoin(jupyter_data_dir(), 'nbextensions/urth_widgets')
     if not os.path.isdir(widgets_dir):
@@ -157,18 +158,18 @@ def bundle_declarative_widgets(output_path, notebook_file):
     # Using find instead of a regex to help future-proof changes that might be
     # to how user's will use urth-core-import
     # (i.e. <link is=urth-core-import> vs. <urth-core-import>)
-    any_cells_with_widgets = any(cell.get('source').find('urth-core-import') != -1 for cell in notebook.cells)
+    any_cells_with_widgets = any(cell.get('source').find('urth-core-') != -1 for cell in notebook.cells)
     if not any_cells_with_widgets:
         return
 
     # Directory of declarative widgets extension
     widgets_dir = pjoin(jupyter_data_dir(), 'nbextensions/urth_widgets')
     # Root of declarative widgets within a dashboard app
-    output_widgets_dir = pjoin(output_path, 'static/urth_widgets/')
+    output_widgets_dir = pjoin(output_path, widget_folder, 'urth_widgets/') if widget_folder is not None else pjoin(output_path, 'urth_widgets/')
     # JavaScript entry point for widgets in dashboard app
     output_js_dir = pjoin(output_widgets_dir, 'js')
     # Web referenceable path from which all urth widget components will be served
-    output_components_dir = pjoin(output_path, 'static/urth_components/')
+    output_components_dir = pjoin(output_path, widget_folder, 'urth_components/') if widget_folder is not None else pjoin(output_path, 'urth_components/')
 
     # Copy declarative widgets js and installed bower components into the app
     # under output directory

--- a/dashboards_bundlers/server_upload/__init__.py
+++ b/dashboards_bundlers/server_upload/__init__.py
@@ -3,21 +3,69 @@
 
 import os
 import requests
+import shutil
+import tempfile
 from notebook.utils import url_path_join
 from tornado import escape, web
 from tornado.log import access_log, app_log
+from ..local_deploy import bundle_file_references, bundle_declarative_widgets, \
+    bundle_web_static
 
 UPLOAD_ENDPOINT = '/_api/notebooks/'
 VIEW_ENDPOINT = '/dashboards/'
 
 def bundle(handler, abs_nb_path):
     '''
-    Uploads a notebook to a Jupyter Dashboard Server
+    Uploads a notebook to a Jupyter Dashboard Server, either by itself, or
+    within a zip file with associated data and widget files
     '''
     # Get name of notebook from filename
     notebook_basename = os.path.basename(abs_nb_path)
     notebook_name = os.path.splitext(notebook_basename)[0]
 
+    # Python 2/3 compatible try/finally to cleanup a temp working directory
+    tmp_dir = tempfile.mkdtemp()
+    try:
+        output_dir = os.path.join(tmp_dir, notebook_name)
+        bundled = make_upload_bundle(abs_nb_path, output_dir, handler.tools)
+        send_file(bundled, notebook_name, handler)
+    finally:
+        shutil.rmtree(tmp_dir, True)
+
+def make_upload_bundle(abs_nb_path, staging_dir, tools):
+    '''
+    Assembles the notebook and resources it needs, returning the path to a
+    zip file bundling the notebook and its requirements if there are any,
+    the notebook's path otherwise.
+    :param abs_nb_path: The path to the notebook
+    :param staging_dir: Temporary work directory, created and removed by the
+        caller
+    '''
+    # Clean up bundle dir if it exists
+    shutil.rmtree(staging_dir, True)
+    os.makedirs(staging_dir)
+
+    # Include the notebook as index.ipynb to make the final URL cleaner
+    # and for consistency
+    shutil.copy2(abs_nb_path, os.path.join(staging_dir, 'index.ipynb'))
+    # Include frontend files referenced via the jupyter_cms bundle mechanism
+    bundle_file_references(staging_dir, abs_nb_path, tools)
+    bundle_declarative_widgets(staging_dir, abs_nb_path, widget_folder=None)
+
+    # if nothing else was required, indicate to upload the notebook itself
+    if len(os.listdir(staging_dir)) == 1:
+        return abs_nb_path
+
+    zip_file = shutil.make_archive(staging_dir, format='zip', root_dir=staging_dir, base_dir='.')
+    return zip_file
+
+def send_file(file_path, dashboard_name, handler):
+    '''
+    Posts a file to the Jupyter Dashboards Server to be served as a dashboard
+    :param file_path: The path of the file to send
+    :param dashboard_name: The dashboard name under which it should be made
+        available
+    '''
     # Make information about the request Host header available for use in
     # constructing the urls
     segs = handler.request.host.split(':')
@@ -34,14 +82,13 @@ def bundle(handler, abs_nb_path):
         dashboard_server = dashboard_server.format(protocol=protocol,
             hostname=hostname, port=port)
         upload_url = url_path_join(dashboard_server, UPLOAD_ENDPOINT,
-            escape.url_escape(notebook_name, False))
-        with open(abs_nb_path, 'rb') as notebook:
+            escape.url_escape(dashboard_name, False))
+        with open(file_path, 'rb') as file_content:
             headers = {}
             token = os.getenv('DASHBOARD_SERVER_AUTH_TOKEN')
             if token:
-                # TODO: server side should expect Authorization: token <value>
                 headers['Authorization'] = 'token {}'.format(token)
-            result = requests.post(upload_url, files={'file': notebook},
+            result = requests.post(upload_url, files={'file': file_content},
                 headers=headers, timeout=60)
             if result.status_code >= 400:
                 raise web.HTTPError(result.status_code)
@@ -53,7 +100,7 @@ def bundle(handler, abs_nb_path):
                 port=port, protocol=protocol)
         else:
             redirect_root = dashboard_server
-        handler.redirect(url_path_join(redirect_root, VIEW_ENDPOINT, escape.url_escape(notebook_name, False)))
+        handler.redirect(url_path_join(redirect_root, VIEW_ENDPOINT, escape.url_escape(dashboard_name, False)))
     else:
         access_log.debug('Can not deploy, DASHBOARD_SERVER_URL not set')
         raise web.HTTPError(500, log_message='No dashboard server configured')

--- a/test/resources/some.csv
+++ b/test/resources/some.csv
@@ -1,0 +1,1 @@
+hello,world

--- a/test/resources/some.ipynb
+++ b/test/resources/some.ipynb
@@ -1,0 +1,36 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "collapsed": true
+   },
+   "source": [
+    "```\n",
+    "some.csv\n",
+    "```"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.4.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}


### PR DESCRIPTION
  Send a zip containing the notebook when directly deploying to a
  Jupyter Dashboards Server.

Fixes #19 