### PR TITLE
Support urth_components as declarative widgets bower dependency directory

### DIFF
--- a/dashboards_bundlers/local_deploy/__init__.py
+++ b/dashboards_bundlers/local_deploy/__init__.py
@@ -175,8 +175,14 @@ def bundle_declarative_widgets(output_path, notebook_file):
     widgets_js_dir = pjoin(widgets_dir, 'js')
     shutil.copytree(widgets_js_dir, output_js_dir)
 
-    # Install the bower components into the output components directory
-    shutil.copytree(pjoin(widgets_dir, 'bower_components'), output_components_dir)
+    # Widgets bower components could be under 'urth_components' or
+    # 'bower_components' depending on the version of widgets being used.
+    widgets_components_dir = pjoin(widgets_dir, 'urth_components')
+    if not os.path.isdir(widgets_components_dir):
+        widgets_components_dir = pjoin(widgets_dir, 'bower_components')
+
+    # Install the widget components into the output components directory
+    shutil.copytree(widgets_components_dir, output_components_dir)
 
 def create_index_html(path, env_vars, fmt, cwd, template_fn):
     '''

--- a/test/test_local_deploy.py
+++ b/test/test_local_deploy.py
@@ -15,7 +15,7 @@ DECL_WIDGETS_DIR = pjoin(jupyter_data_dir(), 'nbextensions/urth_widgets/')
 DECL_WIDGETS_JS_DIR = pjoin(DECL_WIDGETS_DIR, 'js')
 DECL_VIZ_DIR = pjoin(DECL_WIDGETS_DIR, 'components/urth-viz')
 DECL_CORE_DIR = pjoin(DECL_WIDGETS_DIR, 'components/urth-core')
-BOWER_COMPONENT_DIR = pjoin(jupyter_data_dir(), 'nbextensions/urth_widgets/bower_components/component-a')
+BOWER_COMPONENT_DIR = pjoin(jupyter_data_dir(), 'nbextensions/urth_widgets/urth_components/component-a')
 
 class MockHandler(object):
     def __init__(self, notebook_dir):


### PR DESCRIPTION
A change being made to the declarative widgets project (jupyter-incubator/declarativewidgets/pull/225) is renaming the `bower_components` directory to `urth_components` to allow already downloaded dependencies to load even when the server side extension is not installed. This pull request updates the bundler to handle both `urth_components` or `bower_components` directories for backwards compatibility.