### PR TITLE
Fix authorization header format

### DIFF
--- a/dashboards_bundlers/server_upload/__init__.py
+++ b/dashboards_bundlers/server_upload/__init__.py
@@ -40,7 +40,7 @@ def bundle(handler, abs_nb_path):
             token = os.getenv('DASHBOARD_SERVER_AUTH_TOKEN')
             if token:
                 # TODO: server side should expect Authorization: token <value>
-                headers['Authorization'] = token
+                headers['Authorization'] = 'token {}'.format(token)
             result = requests.post(upload_url, files={'file': notebook},
                 headers=headers, timeout=60)
             if result.status_code >= 400:

--- a/test/test_server_upload.py
+++ b/test/test_server_upload.py
@@ -74,7 +74,7 @@ class TestServerUpload(unittest.TestCase):
 
         kwargs = converter.requests.post.kwargs
         self.assertEqual(kwargs['headers'],
-            {'Authorization' : 'fake-token'})
+            {'Authorization' : 'token fake-token'})
 
     def test_url_interpolation(self):
         '''Should build the server URL from the request Host header.'''


### PR DESCRIPTION
Match fix for jupyter-incubator/dashboards_server#127.