### PR TITLE
Option to disable SSL verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ The fourth directly sends your notebook and any associated frontend assets to a 
     * `DASHBOARD_SERVER_URL` - protocol, hostname, and port of the dashboard server to which to send dashboard notebooks
     * `DASHBOARD_REDIRECT_URL` (optional) - protocol, hostname, and port to use when redirecting the user's browser after upload if different from `DASHBOARD_SERVER_URL` and if upload response has no link property from the dashboard server (v0.6.0+)
     * `DASHBOARD_SERVER_AUTH_TOKEN` (optional) - upload token required by the dashboard server
+    * `DASHBOARD_SERVER_NO_SSL_VERIFY` (optional) - skip verification of the dashboard server SSL certificate (for use in dev / trusted environments only!)
 2. Write a notebook.
 3. Define a dashboard layout using the `jupyter_dashboards` extension.
 4. If the notebook requires any frontend assets (e.g., CSS files), [associate them with the notebook](https://github.com/jupyter-incubator/contentmanagement/blob/master/etc/notebooks/associations_demo/associations_demo.ipynb).

--- a/dashboards_bundlers/server_upload/__init__.py
+++ b/dashboards_bundlers/server_upload/__init__.py
@@ -87,8 +87,10 @@ def send_file(file_path, dashboard_name, handler):
             token = os.getenv('DASHBOARD_SERVER_AUTH_TOKEN')
             if token:
                 headers['Authorization'] = 'token {}'.format(token)
+            skip_verify = os.getenv('DASHBOARD_SERVER_NO_SSL_VERIFY', '').lower() in ['yes', 'true']
             result = requests.post(upload_url, files={'file': file_content},
-                headers=headers, timeout=60)
+                headers=headers, timeout=60, 
+                verify=not skip_verify)
             if result.status_code >= 400:
                 raise web.HTTPError(result.status_code)
 

--- a/dashboards_bundlers/server_upload/__init__.py
+++ b/dashboards_bundlers/server_upload/__init__.py
@@ -13,6 +13,13 @@ from ..local_deploy import bundle_file_references, bundle_declarative_widgets
 UPLOAD_ENDPOINT = '/_api/notebooks/'
 VIEW_ENDPOINT = '/dashboards/'
 
+def skip_ssl_verification():
+    return os.getenv('DASHBOARD_SERVER_NO_SSL_VERIFY', '').lower() in ['yes', 'true']
+
+# Log a warning if SSL verification is off at the outset
+if skip_ssl_verification():
+    app_log.warn('Dashboard server SSL verification disabled')
+
 def bundle(handler, abs_nb_path):
     '''
     Uploads a notebook to a Jupyter Dashboard Server, either by itself, or
@@ -87,10 +94,9 @@ def send_file(file_path, dashboard_name, handler):
             token = os.getenv('DASHBOARD_SERVER_AUTH_TOKEN')
             if token:
                 headers['Authorization'] = 'token {}'.format(token)
-            skip_verify = os.getenv('DASHBOARD_SERVER_NO_SSL_VERIFY', '').lower() in ['yes', 'true']
             result = requests.post(upload_url, files={'file': file_content},
                 headers=headers, timeout=60, 
-                verify=not skip_verify)
+                verify=not skip_ssl_verification())
             if result.status_code >= 400:
                 raise web.HTTPError(result.status_code)
 

--- a/test/test_server_upload.py
+++ b/test/test_server_upload.py
@@ -144,3 +144,20 @@ class TestServerUpload(unittest.TestCase):
         self.assertEqual(args[0], 'https://notebook-server:8889/_api/notebooks/no_imports')
         self.assertEqual(handler.last_redirect,
             'http://notebook-server:3000/dashboards/no_imports')
+
+    def test_ssl_verify(self):
+        '''Should verify SSL certificate by default.'''
+        handler = MockHandler()
+        os.environ['DASHBOARD_SERVER_URL'] = '{protocol}://{hostname}:8889'
+        converter.bundle(handler, 'test/resources/no_imports.ipynb')
+        kwargs = converter.requests.post.kwargs
+        self.assertEqual(kwargs['verify'], True)
+        
+    def test_no_ssl_verify(self):
+        '''Should skip SSL certificate verification.'''
+        os.environ['DASHBOARD_SERVER_NO_SSL_VERIFY'] = 'yes'
+        os.environ['DASHBOARD_SERVER_URL'] = '{protocol}://{hostname}:8889'
+        handler = MockHandler()
+        converter.bundle(handler, 'test/resources/no_imports.ipynb')
+        kwargs = converter.requests.post.kwargs
+        self.assertEqual(kwargs['verify'], False)


### PR DESCRIPTION
Tried hard not to include this, but it's quite a bother when
working / testing in dev with self-signed SSL certs


Default is to always verify. Only by setting the DASHBOARDS_SERVER_NO_SSL_VERIFY
to yes or true (case insensitive) will it be disabled