### PR TITLE
Make compatible with notebook bundler API

### DIFF
--- a/dashboards_bundlers/__init__.py
+++ b/dashboards_bundlers/__init__.py
@@ -1,7 +1,7 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 
-def _jupyter_bundler_paths():
+def _jupyter_bundlerextension_paths():
     '''API for notebook bundler installation on notebook 4.2'''
     return [{
             'name': 'dashboards_local_deploy',
@@ -27,3 +27,6 @@ def _jupyter_bundler_paths():
             'module_name': 'dashboards_bundlers.server_download',
             'group': 'download'
         }]
+
+# For backward compatibility with jupyter_cms implementation
+_jupyter_bundler_paths = _jupyter_bundlerextension_paths

--- a/dashboards_bundlers/local_deploy/__init__.py
+++ b/dashboards_bundlers/local_deploy/__init__.py
@@ -34,11 +34,22 @@ def get_extension_path(*parts):
         if os.path.exists(full_path):
             return full_path
 
-def bundle(handler, abs_nb_path):
+def bundle(handler, model):
     '''
     Bundles a notebook as a static web application on this Jupyter Notebook
     server and redirects the requestor there.
     '''
+    try:
+        # Noteook implementation passes ContentManager models. This bundler
+        # only works with local files anyway.
+        abs_nb_path = os.path.join(
+            handler.settings['contents_manager'].root_dir,
+            model['path']
+        )
+    except KeyError:
+        # Original jupyter_cms implementation passes absolute path on disk
+        abs_nb_path = model
+
     # Get name of notebook from filename
     notebook_basename = os.path.basename(abs_nb_path)
     notebook_name = os.path.splitext(notebook_basename)[0]
@@ -53,7 +64,7 @@ def bundle(handler, abs_nb_path):
     # Generate the index.html file
     bundle_index(output_dir, abs_nb_path, DEFAULT_TEMPLATE_PATH)
 
-    # Include frontend files referenced via the jupyter_cms bundle mechanism
+    # Include frontend files referenced via the bundler tools mechanism
     bundle_file_references(output_dir, abs_nb_path, handler.tools)
 
     # Include static web assets (e.g., Thebe)
@@ -90,8 +101,8 @@ def bundle_index(output_path, notebook_fn, template_fn=DEFAULT_TEMPLATE_PATH, in
 
 def bundle_file_references(output_path, notebook_fn, tools):
     '''
-    Looks for files references in the notebook in the manner supported by the
-    jupyter_cms.BundlerTools. Adds those files to the output path if found.
+    Looks for files references in the notebook in the manner supported by
+    notebook.bundler.tools. Adds those files to the output path if found.
 
     :param output_path: The output path of the dashboard being assembled
     :param notebook_fn: The absolute path to the notebook file being packaged

--- a/dashboards_bundlers/php_download/__init__.py
+++ b/dashboards_bundlers/php_download/__init__.py
@@ -85,11 +85,22 @@ using `cf set-env`, the app must be restaged using `cf restage <appname>` to upd
 its environment.
 '''
 
-def bundle(handler, abs_nb_path):
+def bundle(handler, model):
     '''
     Bundles a notebook as a PHP dashboard application and downloads it as a 
     zip file for deployment elsewhere.
     '''
+    try:
+        # Noteook implementation passes ContentManager models. This bundler
+        # only works with local files anyway.
+        abs_nb_path = os.path.join(
+            handler.settings['contents_manager'].root_dir,
+            model['path']
+        )
+    except KeyError:
+        # Original jupyter_cms implementation passes absolute path on disk
+        abs_nb_path = model
+    
     # Get name of notebook from filename
     notebook_basename = os.path.basename(abs_nb_path)
     notebook_name = os.path.splitext(notebook_basename)[0]

--- a/dashboards_bundlers/server_download/__init__.py
+++ b/dashboards_bundlers/server_download/__init__.py
@@ -8,11 +8,22 @@ import tempfile
 from notebook.utils import url_path_join
 from ..server_upload import make_upload_bundle
 
-def bundle(handler, abs_nb_path):
+def bundle(handler, model):
     '''
     Downloads a notebook, either by itself, or within a zip file with associated 
     data and widget files, for manual deployment to a Jupyter Dashboard Server.
     '''
+    try:
+        # Noteook implementation passes ContentManager models. This bundler
+        # only works with local files anyway.
+        abs_nb_path = os.path.join(
+            handler.settings['contents_manager'].root_dir,
+            model['path']
+        )
+    except KeyError:
+        # Original jupyter_cms implementation passes absolute path on disk
+        abs_nb_path = model
+
     # Get name of notebook from filename
     notebook_basename = os.path.basename(abs_nb_path)
     notebook_name = os.path.splitext(notebook_basename)[0]

--- a/dashboards_bundlers/server_upload/__init__.py
+++ b/dashboards_bundlers/server_upload/__init__.py
@@ -20,11 +20,22 @@ def skip_ssl_verification():
 if skip_ssl_verification():
     app_log.warn('Dashboard server SSL verification disabled')
 
-def bundle(handler, abs_nb_path):
+def bundle(handler, model):
     '''
     Uploads a notebook to a Jupyter Dashboard Server, either by itself, or
     within a zip file with associated data and widget files
     '''
+    try:
+        # Noteook implementation passes ContentManager models. This bundler
+        # only works with local files anyway.
+        abs_nb_path = os.path.join(
+            handler.settings['contents_manager'].root_dir,
+            model['path']
+        )
+    except KeyError:
+        # Original jupyter_cms implementation passes absolute path on disk
+        abs_nb_path = model
+
     # Get name of notebook from filename
     notebook_basename = os.path.basename(abs_nb_path)
     notebook_name = os.path.splitext(notebook_basename)[0]

--- a/test/test_server_upload.py
+++ b/test/test_server_upload.py
@@ -58,6 +58,9 @@ class MockRequest(object):
 
 class MockHandler(object):
     def __init__(self, host='notebook-server:8888', protocol='http'):
+        self.settings = {
+            'base_url' : '/'
+        }
         self.request = MockRequest(host, protocol)
         self.last_redirect = None
         self.tools = jupyter_cms.bundler.BundlerTools()


### PR DESCRIPTION
Changes to make the dashboard bundlers compatible with the new bundler API implementation in https://github.com/jupyter/notebook/pull/1579. This can merge before a release with that PR because the code here is backward compatible with the original implementation from jupyter_cms.
