### PR TITLE
Issue 48: bundle_index raises CryptoGen error on Windows

### DIFF
--- a/dashboards_bundlers/local_deploy/__init__.py
+++ b/dashboards_bundlers/local_deploy/__init__.py
@@ -207,6 +207,8 @@ def create_index_html(path, env_vars, fmt, cwd, template_fn):
     if env_vars is None:
         env_vars = {}
     env_vars['PATH'] = os.environ['PATH']
+    if os.name == 'nt' and 'SystemRoot' in os.environ:
+        env_vars['SystemRoot'] = os.environ['SystemRoot']
 
     # Always search for templates in the default template path as well as the
     # directory containing the provided template


### PR DESCRIPTION
Add the SystemRoot value into the environment executing nbconvert
(c) Copyright IBM Corp. 2016